### PR TITLE
Add get_lower_128 method

### DIFF
--- a/src/arithmetic/fields.rs
+++ b/src/arithmetic/fields.rs
@@ -111,6 +111,10 @@ pub trait FieldExt: ff::PrimeField + BaseExt + Group<Scalar = Self> {
     /// Attempts to obtain a field element from its normalized, little endian
     /// byte representation.
     fn from_bytes(bytes: &[u8; 32]) -> CtOption<Self>;
+
+    /// Gets the lower 128 bits of this field element when expressed
+    /// canonically.
+    fn get_lower_128(&self) -> u128;
 }
 
 /// Compute a + b + carry, returning the result and the new carry over.

--- a/src/bn256/fr.rs
+++ b/src/bn256/fr.rs
@@ -654,6 +654,12 @@ impl FieldExt for Fr {
     fn to_bytes(&self) -> [u8; 32] {
         <Self as ff::PrimeField>::to_repr(self)
     }
+
+    fn get_lower_128(&self) -> u128 {
+        let tmp = Fr::montgomery_reduce(self.0[0], self.0[1], self.0[2], self.0[3], 0, 0, 0, 0);
+
+        u128::from(tmp.0[0]) | (u128::from(tmp.0[1]) << 64)
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Hi @kilic 
I added `get_lower_128` because our `zkevm-circuit` using [here](https://github.com/NoCtrlZ/zkevm-circuits/blob/main/zkevm-circuits/src/evm_circuit/op_execution/utils/memory_gadgets.rs#L26).
I referred the original [implementation](https://github.com/zcash/pasta_curves/blob/main/src/fields/fq.rs#L766).

I would appreciate you could confirm!
Thank you.